### PR TITLE
Add nil checking and protection in cases where the get on /profile returns nil

### DIFF
--- a/lib/trip_it/classes/profile.rb
+++ b/lib/trip_it/classes/profile.rb
@@ -11,26 +11,28 @@ module TripIt
     end
     
     def populate(source)
-      info = source || @client.get("/profile")["Profile"]
+      info = source || @client.get("/profile").try(:fetch, "Profile")
       
-      @screen_name              = info['screen_name']
-      @public_display_name      = info['public_display_name']
-      @profile_url              = info['profile_url']
-      @home_city                = info['home_city']
-      @company                  = info['company']
-      @about_me_info            = info['about_me_info']
-      @photo_url                = info['photo_url']
-      @activity_feed_url        = info['activity_feed_url']
-      @alerts_feed_url          = info['alerts_feed_url']
-      @is_pro                   = Boolean(info['is_pro'])
-      @is_client                = Boolean(info['is_client'])
-      @ical_url                 = info['ical_url']
-      @ref                      = info['@attributes']['ref']
-      @profile_email_addresses  = []
-      @group_memberships        = []
+      unless info.nil?
+        @screen_name              = info['screen_name']
+        @public_display_name      = info['public_display_name']
+        @profile_url              = info['profile_url']
+        @home_city                = info['home_city']
+        @company                  = info['company']
+        @about_me_info            = info['about_me_info']
+        @photo_url                = info['photo_url']
+        @activity_feed_url        = info['activity_feed_url']
+        @alerts_feed_url          = info['alerts_feed_url']
+        @is_pro                   = Boolean(info['is_pro'])
+        @is_client                = Boolean(info['is_client'])
+        @ical_url                 = info['ical_url']
+        @ref                      = info['@attributes']['ref']
+        @profile_email_addresses  = []
+        @group_memberships        = []
       
-      chkAndPopulate(@profile_email_addresses, TripIt::ProfileEmailAddress, info['ProfileEmailAddresses']['ProfileEmailAddress']) unless info['ProfileEmailAddresses'].nil?
-      chkAndPopulate(@group_memberships, TripIt::Group, info['GroupMemberships']['Group']) unless info['GroupMemberships'].nil?
+        chkAndPopulate(@profile_email_addresses, TripIt::ProfileEmailAddress, info['ProfileEmailAddresses']['ProfileEmailAddress']) unless info['ProfileEmailAddresses'].nil?
+        chkAndPopulate(@group_memberships, TripIt::Group, info['GroupMemberships']['Group']) unless info['GroupMemberships'].nil?
+      end
     end
     
     def trips(params = {})


### PR DESCRIPTION
While using the TripIt library, we noticed a number of instances where the /profile GET was returning nil, and thus throwing exceptions on the hash fetch for ["Profile"]. I've added protection for these cases in the populate method.
