### PR TITLE
Add support for 403 and 503 TripIt status codes

### DIFF
--- a/lib/trip_it/classes/profile.rb
+++ b/lib/trip_it/classes/profile.rb
@@ -67,5 +67,13 @@ module TripIt
       end
       return @progArr
     end
+    
+    def subscribe_trips
+      @client.subscribe("/trip")
+    end
+    
+    def unsubscribe
+      @client.unsubscribe
+    end
   end
 end

--- a/lib/trip_it/oauth.rb
+++ b/lib/trip_it/oauth.rb
@@ -59,6 +59,16 @@ module TripIt
       returnResponse(request)
     end
     
+    def subscribe(resource)
+      request = access_token.get("/v1/subscribe/type#{resource}")
+      returnResponse(request)
+    end
+    
+    def unsubscribe
+      request = access_token.get("/v1/unsubscribe")
+      returnResponse(request)
+    end
+    
     def returnResponse(request, format = "")
       case request
       when Net::HTTPOK


### PR DESCRIPTION
Per the TripIt API documentation, the oauth client was missing support for the 403 and 503 error codes. I've added to round out support for all documented status codes.
