### PR TITLE
Fixed a typo in line 96 of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Create a **TripIt::OAuth** instance with your consumer token and secret. Authori
 	mytrip.lodging => [TripIt::LodgingObject]
 	
 	# Get some info on the first hotel stay of this trip
-	hot = mytrip.lodging.first
+	hot = mytrip.lodgings.first
 	hot.supplier_name => "Westin Times Square"
 	hot.room_type => "Presidential Suite"
 	


### PR DESCRIPTION
This gem is great, thanks! I noticed that to find a trip's associated lodging objects you need to call mytrip.lodgings and not lodging.
